### PR TITLE
make bundle conjure-up enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Production-grade Kubernetes cluster with logging and monitoring
 
-## Overview
+# Overview
 
 This is a Kubernetes bundle that also includes logging and monitoring. It is
 comprised of the following components and features:
 
 - Kubernetes (automating deployment, operations, and scaling containers)
-  - Three node Kubernetes cluster where each unit is a master and a node.  
+  - Three node Kubernetes cluster where each unit is a master and a node.
   - TLS used for communication between nodes for security.
   - ZFS used as a docker datastore for resilience and performance.
 - Etcd (distributed key value store)
@@ -20,7 +20,7 @@ comprised of the following components and features:
 
 # Usage
 
-    juju deploy cs:~containers/observable-kubernetes
+    conjure-up battlemidget/bundle-observable-kubernetes
 
 Any of the services provided can be scaled out post-deployment. The charms
 update the status messages with progress, so it is recommended to run
@@ -32,7 +32,7 @@ control the cluster:
     tar zxf kubectl_package.tar
     ./kubectl get pods
 
-You should not have the kubectl command and configuration for the cluster that
+You should now have the kubectl command and configuration for the cluster that
 was just created, you can now check the state of the cluster:
 
     ./kubectl cluster-health

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -1,7 +1,7 @@
 series: trusty
 services:
   etcd:
-    charm: "cs:~containers/trusty/etcd-1"
+    charm: "cs:~containers/trusty/etcd-2"
     num_units: 3
     annotations:
       "gui-x": "1200"
@@ -33,7 +33,7 @@ services:
       "gui-x": "300"
       "gui-y": "300"
   elasticsearch:
-    charm: "cs:trusty/elasticsearch-14"
+    charm: "cs:trusty/elasticsearch-15"
     num_units: 2
     annotations:
       "gui-x": "600"

--- a/conjure/metadata.json
+++ b/conjure/metadata.json
@@ -1,0 +1,14 @@
+{
+    "container-types": {
+        "etcd": [
+            "LXD",
+            "BareMetal"
+        ],
+        "kubernetes": [
+            "LXD",
+            "BareMetal"
+        ]
+    },
+    "spell-name": "kubernetes",
+    "version": 1
+}

--- a/conjure/steps/00_pre.sh
+++ b/conjure/steps/00_pre.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+. /usr/share/conjure-up/hooklib/common.sh
+
+if [[ $JUJU_PROVIDERTYPE =~ "lxd" ]]; then
+    debug openstack "(pre) processing lxd"
+
+    profilename=$(juju switch | cut -d: -f2)
+    sed "s/##MODEL##/$profilename/" $SCRIPTPATH/lxd-profile.yaml | lxc profile edit "juju-$profilename"
+
+    RET=$?
+    if [ $RET -ne 0 ]; then
+        exposeResult "(pre) Failed to update lxd profile" $RET "false"
+    else
+        exposeResult "(pre) Complete" 0 "true"
+    fi
+
+fi
+
+exposeResult "Finished pre-processing..." 0 "true"

--- a/conjure/steps/01_get-kubectl.sh
+++ b/conjure/steps/01_get-kubectl.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Description: Download kubectl for controlling Kubernetes Cluster
+
+. /usr/share/conjure-up/hooklib/common.sh
+
+KUBECTL_PATH=$HOME/conjure-up/kubernetes
+mkdir -p $KUBECTL_PATH || true
+
+while [ $(unitStatus kubernetes 0) != "active" ]; do sleep 5; done
+
+# TODO: Convert to an actionable item
+juju scp kubernetes/0:kubectl_package.tar $KUBECTL_PATH/.
+cd $KUBECTL_PATH && tar zxf kubectl_package.tar
+
+exposeResult "Cluster can now be accessed with $KUBECTL_PATH/kubectl application" 0 "true"

--- a/conjure/steps/lxd-profile.yaml
+++ b/conjure/steps/lxd-profile.yaml
@@ -1,0 +1,18 @@
+name: docker
+config:
+  linux.kernel_modules: overlay, nf_nat
+  security.nesting: "true"
+description: Profile supporting docker in containers
+devices:
+  aadisable:
+    path: /sys/module/apparmor/parameters/enabled
+    source: /dev/null
+    type: disk
+  fuse:
+    path: /dev/fuse
+    type: unix-char
+  eth0:
+    name: eth0
+    nictype: bridged
+    parent: lxdbr0
+    type: nic


### PR DESCRIPTION
This is the first bundle that I've 'enabled' to be used with conjure-up. Basically we place all of our needed metadata inside the conjure/ directory.

This is just the first step in getting it ready. I am still working with the charmstore api to get the other end of the metadata added so it can be searchable down the road.

Testing this out with the latest conjure-up is pretty straightforward, as of this writing you'll want to use the headless mode for now:

```
sudo apt-add-repository ppa:conjure/next
sudo apt update
sudo apt install conjure-up
conjure-up juju-solutions/bundle-observable-kubernetes to localhost
```

This will go through and bootstrap juju, deploy the bundle, setup the lxd profile for use with the juju model, and perform a post step to download kubectl for further use of the cluster.

Keep in mind all this is pretty new but the specification of steps is documented https://github.com/ubuntu/conjure-up/wiki/Spell-Step-Specification

Note: once this goes into the charmstore you can deploy directly from that with:

```
conjure-up ~containers/observable-kubernetes to localhost
```

Thanks