### PR TITLE
Patch makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+# Makefile for observable kubernetes
+
+.PHONY: metadata
+metadata:
+	@echo "Updating extra-info metadata for bundle"
+	@charm set cs:~containers/bundle/observable-kubernetes conjure:='{"friendly-name": "Observable Kubernetes", "version": 1}'
+
+all: metadata

--- a/conjure/steps/01_get-kubectl.sh
+++ b/conjure/steps/01_get-kubectl.sh
@@ -20,7 +20,7 @@ if [ $(unitStatus kubernetes 0) != "active" ]; then
 fi
 
 # TODO: Convert to an actionable item
-juju scp kubernetes/0:kubectl_package.tar $KUBECTL_PATH/.
+juju scp kubernetes/0:kubectl_package.tar.gz $KUBECTL_PATH/.
 cd $KUBECTL_PATH && tar zxf kubectl_package.tar
 
 exposeResult "Cluster can now be accessed with $KUBECTL_PATH/kubectl application" 0 "true"

--- a/conjure/steps/01_get-kubectl.sh
+++ b/conjure/steps/01_get-kubectl.sh
@@ -21,6 +21,6 @@ fi
 
 # TODO: Convert to an actionable item
 juju scp kubernetes/0:kubectl_package.tar.gz $KUBECTL_PATH/.
-cd $KUBECTL_PATH && tar zxf kubectl_package.tar
+cd $KUBECTL_PATH && tar zxf kubectl_package.tar.gz
 
 exposeResult "Cluster can now be accessed with $KUBECTL_PATH/kubectl application" 0 "true"


### PR DESCRIPTION
This allows you to quickly update the extra-info metadata when a new bundle release is pushed into the charmstore. Please include this in your release workflow to be done after a `charm publish`

`make metadata`

