### PR TITLE
Fix kubectl cluster-health command

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ see the Kubernetes [user guide](http://kubernetes.io/docs/user-guide/).
 
 To check the state of the cluster:
 
-    ./kubectl cluster-health --kubeconfig ./kubeconfig
+    ./kubectl cluster-info --kubeconfig ./kubeconfig
 
 Now you can run pods inside the Kubernetes cluster:
 


### PR DESCRIPTION
Looks like kubectl renamed cluster-health to cluster-info; update
readme to reflet that.

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>