### PR TITLE
add localhost to cloud-blacklist

### DIFF
--- a/conjure/metadata.json
+++ b/conjure/metadata.json
@@ -1,4 +1,5 @@
 {
     "friendly-name": "Kubernetes",
-    "version": 1
+    "version": 1,
+    "cloud-blacklist": ["localhost"]
 }


### PR DESCRIPTION
Kubernetes and friends don't really work that well under LXD/Localhost,
so we blacklist that cloud for now. This gives the user only the options
of all supported public clouds from juju in addition to MAAS.

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>