### PR TITLE
update tag for name consistency

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -61,5 +61,5 @@ relations:
 description: |
   Production-grade Kubernetes cluster with logging and monitoring
 tags:
-  - conjure-kubernetes
+  - conjure-up-kubernetes
   - kubernetes


### PR DESCRIPTION
To not confuse people keep the tags prefixed with the same name as the
application 'conjure-up' vs 'conjure'

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>