### PR TITLE
Bumps kubernetes to the latest release

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -12,7 +12,7 @@ tags:
 - kubernetes
 services:
   kubernetes:
-    charm: cs:~containers/xenial/kubernetes-8
+    charm: cs:xenial/kubernetes-7
     options:
       version: v1.3.5
     expose: true


### PR DESCRIPTION
This release adds Operational Actions to the juju charm, where the
operator can pause/resume nodes.

Test run results:
```
PASS: 16 Total: 16 (1244.214486 sec)
```