### PR TITLE
Bumps Elasticsearch to -18 for messaging fix

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -50,7 +50,7 @@ services:
       gui-y: '300'
   elasticsearch:
     series: trusty
-    charm: cs:trusty/elasticsearch-17
+    charm: cs:trusty/elasticsearch-18
     num_units: 2
     annotations:
       gui-x: '600'


### PR DESCRIPTION
Bumps ES charm to rev 18. Status now sets to 'active' and Ready on extant services/start invocation.